### PR TITLE
Add sub_idx field to SdoEntryInfo

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ pub struct SdoIdx {
 /// SDO Meta Information
 #[derive(Debug, Clone, PartialEq)]
 pub struct SdoInfo {
-    pub pos: SdoPos, // TODO: do we need this info here?
+    pub pos: SdoPos,
     pub idx: Idx,
     pub max_sub_idx: SubIdx,
     pub object_code: Option<u8>,
@@ -119,6 +119,7 @@ pub struct SdoInfo {
 /// SDO Entry Information
 #[derive(Debug, Clone, PartialEq)]
 pub struct SdoEntryInfo {
+    pub sub_idx: SubIdx,
     pub data_type: DataType,
     pub bit_len: u16,
     pub access: SdoEntryAccess,


### PR DESCRIPTION
In some contexts I'd like to know the SubIdx of an entry, so I think it's appropriate to add this field.
What do you think?

BTW: This is a breaking change.